### PR TITLE
Add continuous cell drawing on drag

### DIFF
--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -164,6 +164,13 @@ class GameLogic {
             this.grid[x][y] = 1 - this.grid[x][y];
         }
     }
+
+    // Set the state of a cell directly (used for drawing/erasing)
+    setCellState(x, y, state) {
+        if (x >= 0 && x < this.cols && y >= 0 && y < this.rows) {
+            this.grid[x][y] = state;
+        }
+    }
     
     setGenre(genre) {
         this.currentGenre = genre;

--- a/js/main.js
+++ b/js/main.js
@@ -90,6 +90,10 @@ function mousePressed() {
     uiControls.handleMouseClick(mouseX, mouseY);
 }
 
+function mouseDragged() {
+    uiControls.handleMouseDrag(mouseX, mouseY);
+}
+
 function keyPressed() {
     uiControls.handleKeyPress(key);
 }

--- a/js/uiControls.js
+++ b/js/uiControls.js
@@ -116,6 +116,15 @@ class UIControls {
             this.gameLogic.toggleCell(col, row);
         }
     }
+
+    // Continuously draw cells while the mouse is dragged
+    handleMouseDrag(mouseX, mouseY) {
+        if (mouseX >= 0 && mouseX < width && mouseY >= 0 && mouseY < height) {
+            let col = floor(mouseX / this.visualizer.cellSize);
+            let row = floor(mouseY / this.visualizer.cellSize);
+            this.gameLogic.setCellState(col, row, 1);
+        }
+    }
     
     handleKeyPress(key) {
         if (key === ' ') {


### PR DESCRIPTION
## Summary
- allow drawing cells continuously by adding a `setCellState` helper
- add UI control for mouse dragging to paint cells
- connect `mouseDragged` p5 handler to keep drawing while the mouse is held
