### PR TITLE
Add fullscreen mode for canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
                     <button id="randomize" class="action-btn">Zufall</button>
                     <button id="clear" class="action-btn">Leeren</button>
                     <button id="export" class="action-btn">Exportieren</button>
+                    <button id="fullscreenToggle" class="action-btn">Fullscreen</button>
                 </div>
             </div>
         </div>

--- a/js/uiControls.js
+++ b/js/uiControls.js
@@ -75,6 +75,10 @@ class UIControls {
         document.getElementById('export').addEventListener('click', () => {
             this.exportCanvas();
         });
+
+        document.getElementById('fullscreenToggle').addEventListener('click', () => {
+            this.toggleFullscreen();
+        });
     }
     
     handleAudioFile(event) {
@@ -107,6 +111,33 @@ class UIControls {
     
     exportCanvas() {
         saveCanvas('audio-reactive-game-of-life', 'png');
+    }
+
+    toggleFullscreen() {
+        const container = document.getElementById('gameOfLife');
+        if (!document.fullscreenElement) {
+            if (container.requestFullscreen) {
+                container.requestFullscreen();
+            } else if (container.webkitRequestFullscreen) {
+                container.webkitRequestFullscreen();
+            }
+            resizeCanvas(window.innerWidth, window.innerHeight);
+            const cols = floor(width / this.visualizer.cellSize);
+            const rows = floor(height / this.visualizer.cellSize);
+            this.gameLogic.resizeGrid(cols, rows);
+        } else {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            } else if (document.webkitExitFullscreen) {
+                document.webkitExitFullscreen();
+            }
+            windowResized();
+        }
+        container.classList.toggle('fullscreen');
+        const btn = document.getElementById('fullscreenToggle');
+        if (btn) {
+            btn.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
+        }
     }
     
     updateStats() {
@@ -154,6 +185,8 @@ class UIControls {
             const colorToggle = document.getElementById('colorMode');
             colorToggle.checked = !colorToggle.checked;
             this.visualizer.setColorMode(colorToggle.checked);
+        } else if (key === 'f' || key === 'F') {
+            this.toggleFullscreen();
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -236,6 +236,19 @@ a:hover{
     display: block;
 }
 
+/* Fullscreen adjustments */
+.game-canvas.fullscreen {
+    width: 100vw !important;
+    height: 100vh !important;
+    max-height: none;
+    border-radius: 0;
+}
+
+.game-canvas.fullscreen canvas {
+    height: 100% !important;
+    max-height: none;
+}
+
 .frequency-display {
     background: #18181B;
     backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- add a fullscreen toggle button in the action menu
- style canvas container when in fullscreen
- implement fullscreen handling in UIControls
- support keyboard shortcut `f`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6883acfdd2dc8327b75bb0394ab38adb