### PR TITLE
Resolve fullscreen toggle merge conflicts

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,16 @@
         </div>
 
         <div class="visualization-container">
-            <div id="gameOfLife" class="game-canvas"></div>
+            <div id="gameOfLife" class="game-canvas">
+                <button id="fullscreenToggle" class="fullscreen-btn" aria-label="Fullscreen">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="15 3 21 3 21 9"></polyline>
+                        <polyline points="9 21 3 21 3 15"></polyline>
+                        <line x1="21" y1="3" x2="14" y2="10"></line>
+                        <line x1="3" y1="21" x2="10" y2="14"></line>
+                    </svg>
+                </button>
+            </div>
             
             <div class="frequency-display">
                 <div class="freq-bar">

--- a/js/main.js
+++ b/js/main.js
@@ -70,18 +70,23 @@ function draw() {
 
 function windowResized() {
     const container = document.getElementById('gameOfLife');
-    if (container) {
-        const containerWidth = container.offsetWidth;
-        const containerHeight = Math.min(600, window.innerHeight * 0.6);
-        
-        resizeCanvas(containerWidth, containerHeight);
-        
-        // Update grid dimensions when canvas resizes
-        if (visualizer) {
-            const cols = floor(width / visualizer.cellSize);
-            const rows = floor(height / visualizer.cellSize);
-            gameLogic.resizeGrid(cols, rows);
-        }
+    if (!container) return;
+
+    let targetWidth = container.offsetWidth;
+    let targetHeight = Math.min(600, window.innerHeight * 0.6);
+
+    if (document.fullscreenElement === container) {
+        targetWidth = window.innerWidth;
+        targetHeight = window.innerHeight;
+    }
+
+    resizeCanvas(targetWidth, targetHeight);
+
+    // Update grid dimensions when canvas resizes
+    if (visualizer) {
+        const cols = floor(width / visualizer.cellSize);
+        const rows = floor(height / visualizer.cellSize);
+        gameLogic.resizeGrid(cols, rows);
     }
 }
 

--- a/js/uiControls.js
+++ b/js/uiControls.js
@@ -4,9 +4,25 @@ class UIControls {
         this.audioManager = audioManager;
         this.gameLogic = gameLogic;
         this.visualizer = visualizer;
-        
+
         // Hinweis-Element referenzieren
         this.uploadHint = document.getElementById('uploadHint');
+
+        // Icons for fullscreen toggle
+        this.fullscreenIcon = `
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="15 3 21 3 21 9"></polyline>
+                <polyline points="9 21 3 21 3 15"></polyline>
+                <line x1="21" y1="3" x2="14" y2="10"></line>
+                <line x1="3" y1="21" x2="10" y2="14"></line>
+            </svg>`;
+        this.exitFullscreenIcon = `
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 3 3 3 3 9"></polyline>
+                <polyline points="15 21 21 21 21 15"></polyline>
+                <line x1="3" y1="3" x2="10" y2="10"></line>
+                <line x1="21" y1="21" x2="14" y2="14"></line>
+            </svg>`;
 
         this.setupEventListeners();
     }
@@ -75,6 +91,29 @@ class UIControls {
         document.getElementById('export').addEventListener('click', () => {
             this.exportCanvas();
         });
+
+        // Fullscreen toggle button
+        const fullscreenBtn = document.getElementById('fullscreenToggle');
+        if (fullscreenBtn) {
+            fullscreenBtn.addEventListener('click', () => {
+                this.toggleFullscreen();
+            });
+            fullscreenBtn.innerHTML = this.fullscreenIcon;
+        }
+
+        // Update icon, container class and canvas sizing when fullscreen state changes
+        document.addEventListener('fullscreenchange', () => {
+            const btn = document.getElementById('fullscreenToggle');
+            const container = document.getElementById('gameOfLife');
+            const isFullscreen = document.fullscreenElement === container;
+            if (btn) {
+                btn.innerHTML = isFullscreen ? this.exitFullscreenIcon : this.fullscreenIcon;
+            }
+            if (container) {
+                container.classList.toggle('fullscreen', isFullscreen);
+            }
+            windowResized();
+        });
     }
     
     handleAudioFile(event) {
@@ -107,6 +146,23 @@ class UIControls {
     
     exportCanvas() {
         saveCanvas('audio-reactive-game-of-life', 'png');
+    }
+
+    toggleFullscreen() {
+        const container = document.getElementById('gameOfLife');
+        if (!document.fullscreenElement) {
+            if (container.requestFullscreen) {
+                container.requestFullscreen();
+            } else if (container.webkitRequestFullscreen) {
+                container.webkitRequestFullscreen();
+            }
+        } else {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            } else if (document.webkitExitFullscreen) {
+                document.webkitExitFullscreen();
+            }
+        }
     }
     
     updateStats() {

--- a/styles.css
+++ b/styles.css
@@ -236,6 +236,46 @@ a:hover{
     display: block;
 }
 
+/* Fullscreen toggle button */
+.fullscreen-btn {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    width: 40px;
+    height: 40px;
+    background: rgba(0, 0, 0, 0.5);
+    border: none;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: #fff;
+    z-index: 10;
+}
+
+.fullscreen-btn:hover {
+    background: rgba(0, 0, 0, 0.7);
+}
+
+/* Allow clicks through SVG icon */
+.fullscreen-btn svg {
+    pointer-events: none;
+}
+
+/* Fullscreen adjustments */
+.game-canvas.fullscreen {
+    width: 100vw !important;
+    height: 100vh !important;
+    max-height: none;
+    border-radius: 0;
+}
+
+.game-canvas.fullscreen canvas {
+    height: 100% !important;
+    max-height: none;
+}
+
 .frequency-display {
     background: #18181B;
     backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- keep fullscreen toggle only on canvas icon and sync fullscreen class on fullscreen changes
- streamline fullscreen logic and drop keyboard shortcut to avoid duplicate controls

## Testing
- `node --check js/uiControls.js`
- `node --check js/main.js`
- `rg '<<<<<<<' -n`


------
https://chatgpt.com/codex/tasks/task_e_6883acfdd2dc8327b75bb0394ab38adb