### PR TITLE
Add fullscreen toggle button to canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,14 @@
         </div>
 
         <div class="visualization-container">
-            <div id="gameOfLife" class="game-canvas"></div>
-            
+            <div id="gameOfLife" class="game-canvas">
+                <button id="fullscreenBtn" class="fullscreen-btn" aria-label="Vollbild">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 3h6v2H5v4H3V3zm18 0v6h-2V5h-4V3h6zm0 18h-6v-2h4v-4h2v6zM3 21v-6h2v4h4v2H3z"/>
+                    </svg>
+                </button>
+            </div>
+
             <div class="frequency-display">
                 <div class="freq-bar">
                     <label>Bass</label>

--- a/js/uiControls.js
+++ b/js/uiControls.js
@@ -75,6 +75,12 @@ class UIControls {
         document.getElementById('export').addEventListener('click', () => {
             this.exportCanvas();
         });
+
+        // Fullscreen toggle
+        const fsBtn = document.getElementById('fullscreenBtn');
+        fsBtn.addEventListener('click', () => {
+            this.toggleFullscreen();
+        });
     }
     
     handleAudioFile(event) {
@@ -107,6 +113,11 @@ class UIControls {
     
     exportCanvas() {
         saveCanvas('audio-reactive-game-of-life', 'png');
+    }
+
+    toggleFullscreen() {
+        const fs = fullscreen();
+        fullscreen(!fs);
     }
     
     updateStats() {

--- a/styles.css
+++ b/styles.css
@@ -236,6 +236,27 @@ a:hover{
     display: block;
 }
 
+.fullscreen-btn {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    border-radius: 8px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: white;
+    z-index: 10;
+}
+
+.fullscreen-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
 .frequency-display {
     background: #18181B;
     backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- add fullscreen button with icon to Game of Life canvas
- style fullscreen button in bottom-right corner
- handle fullscreen toggling via UIControls

## Testing
- `npm test` (fails: ENOENT cannot find package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a08ee08448832799679d7c02eb8514